### PR TITLE
Suporte a `c-remove` e melhoria do `c-remove-closest` em cru.js

### DIFF
--- a/src/cru.js
+++ b/src/cru.js
@@ -1,4 +1,3 @@
-
 const $cru = (el) => document.querySelector(el)
 const $crus = (el) => document.querySelectorAll(el)
 
@@ -17,21 +16,21 @@ const $C = (config = false) => {
     $cruLoadEvents()
 }
 
-const $cruLoadElementEvents = () => {
-    $crus('[c-remove]:not(.c-form):not(.loaded)').forEach((el) => {
-        el.classList.add('loaded')
-        el.addEventListener('click', (e) => {
-            const selector = el.getAttribute('c-remove')
-            selector.split(';').forEach(sel => $crus(sel).forEach(e => e.remove()))
-        })
-    })
-}
-
 const $cruLoadEvents = () => {
     $cruLoadRequests()
     $cruLoadFormIntercept()
     $cruLoadAllContainers()
     $cruLoadElementEvents()
+}
+
+const $cruLoadElementEvents = () => {
+    $crus('[c-remove]:not(.loaded)').forEach((el) => {
+        el.classList.add('loaded')
+        el.addEventListener('click', (e) => {
+            const selector = el.getAttribute('c-remove')
+            if (selector) selector.split(';').forEach(sel => $crus(sel).forEach(e => e.remove()))
+        })
+    })
 }
 
 const $cruLoadContainer = async (el) => {
@@ -46,27 +45,22 @@ const $cruLoadContainer = async (el) => {
         method: 'GET', 
         headers: $cruConfig['headers']
     })
+    
     const content = await $cruTypeResponse(type, response)
-    const $target = target ? $cru(target):container
+	const $target = target ? $cru(target):container 
 
-    if (target || target != 'off') {
-        if(target)$target.innerHTML = content
-        else if (type == 'html') $target.innerHTML = content
-    }
-    if (callback) {
-        $cruConfig['callbacks'][callback](content, $target)
-    }
-
+	if (target != 'off') $target.innerHTML = content
+    if (callback) $cruConfig['callbacks'][callback](content, $target)
     $cruLoadEvents()
 }
 
 const $cruLoadAllContainers = async () => {
-
-    $crus('[c-container]:not(.loaded)').forEach( async (el) => {
+    $crus('[c-container]:not(.loaded)').forEach((el) => {
         el.classList.add('loaded')
         $cruLoadContainer(el)
     })
-    $crus('[c-reload]:not(.loaded)').forEach( async (el) => {
+
+    $crus('[c-reload]:not(.loaded)').forEach((el) => {
         el.classList.add('loaded')
         el.addEventListener('click', (ev) => $cruLoadContainer(el))
     })
@@ -75,20 +69,21 @@ const $cruLoadAllContainers = async () => {
 const cruRequest = async (el, method) => {
     const url = el.getAttribute(`c-${method}`)
     const type = el.getAttribute('c-type') || 'html'
-    const reloadContainer = el.getAttribute('c-reload-container') || false;
+    const reloadContainer = el.getAttribute('c-reload-container') || false
     const removeClosest = el.getAttribute('c-remove-closest') || false
     const selfRemove = el.getAttribute('c-self-remove') || false
     const redirect = el.getAttribute('c-redirect') || false
-    const swap = el.getAttribute('c-swap') || false;
-    const append = el.getAttribute('c-append') || false;
-    const prepend = el.getAttribute('c-prepend') || false;
+    const swap = el.getAttribute('c-swap') || false
+    const append = el.getAttribute('c-append') || false
+    const prepend = el.getAttribute('c-prepend') || false
     const callback = el.getAttribute('c-callback') || false
-    const target = el.getAttribute('c-target') || false;
+    const target = el.getAttribute('c-target') || false
 
     const response = await fetch($cruConfig['prefix_url'] + url, {
         method: method, 
         headers: $cruConfig['headers']
     })
+	
     const content = await $cruTypeResponse(type, response)
     const $target = target ? $cru(target):false
 
@@ -98,44 +93,19 @@ const cruRequest = async (el, method) => {
     if (append) $cru(append).insertAdjacentHTML('beforeend', content)
     if (prepend) $cru(prepend).insertAdjacentHTML('afterbegin', content)
     if (reloadContainer) $cruLoadContainer(el)
-    
-    if ($target) {
-        if ($target) {
-            $target.innerHTML = content
-        } else if (type == 'html') {
-            el.innerHTML = content
-        }
-    }
+   	
+	if ($target) $target.innerHTML = content
     if (callback) $cruConfig['callbacks'][callback](content, $target)
     $cruLoadEvents()
-    if (redirect) {
-        window.location.href = redirect
-    }
+    if (redirect) window.location.href = redirect
+
 }
 
 const $cruLoadRequests = () => {
-    $crus('[c-delete]:not(.loaded)').forEach( (el) => {
-        el.classList.add('loaded')
-        el.addEventListener('click', async (e) => {
-            cruRequest(el, 'delete')
-        })
-    })
-    $crus('[c-put]:not(.loaded)').forEach( (el) => {
-        el.classList.add('loaded')
-        el.addEventListener('click', async (e) => {
-            cruRequest(el, 'put')
-        })
-    })
-    $crus('[c-get]:not(.loaded)').forEach( (el) => {
-        el.classList.add('loaded')
-        el.addEventListener('click', async (e) => {
-            cruRequest(el, 'get')
-        })
-    })
-    $crus('[c-post]:not(.loaded)').forEach( (el) => {
-        el.classList.add('loaded')
-        el.addEventListener('click', async (e) => {
-            cruRequest(el, 'post')
+    ['delete', 'put', 'get', 'post'].forEach(method => {
+        $crus(`[c-${method}]:not(.loaded)`).forEach((el) => {
+            el.classList.add('loaded')
+			el.addEventListener('click', () => cruRequest(el, method.toUpperCase()))
         })
     })
 }
@@ -147,16 +117,16 @@ const $cruLoadFormIntercept = () => {
             e.preventDefault()
             const url = form.getAttribute('action')
             const method = form.getAttribute('method').toUpperCase() || 'POST'
-            const type = form.getAttribute('c-type') || 'html';
-            const append = form.getAttribute('c-append') || false;
-            const prepend = form.getAttribute('c-prepend') || false;
-            const redirect = form.getAttribute('c-redirect') || false;
-            const reset = form.getAttribute('c-reset') || false;
-            const swap = form.getAttribute('c-swap') || false;
-            const target = form.getAttribute('c-target') || false;
-            const reloadContainer = form.getAttribute('c-reload-container') || false;
-            const callback = form.getAttribute('c-callback') || false
+            const type = form.getAttribute('c-type') || 'html'
+            const append = form.getAttribute('c-append') || false
+            const prepend = form.getAttribute('c-prepend') || false
+            const redirect = form.getAttribute('c-redirect') || false
+            const reset = form.getAttribute('c-reset') || false
+            const swap = form.getAttribute('c-swap') || false
+            const target = form.getAttribute('c-target') || false
+            const reloadContainer = form.getAttribute('c-reload-container') || false
             const removeClosest = form.getAttribute('c-remove-closest') || false
+            const callback = form.getAttribute('c-callback') || false
             const isRead = $cruIsRead(method)
 
             const data = Object.fromEntries(new FormData(e.target).entries());
@@ -174,16 +144,15 @@ const $cruLoadFormIntercept = () => {
             if (append) $cru(append).insertAdjacentHTML('beforeend', content)
             if (prepend) $cru(prepend).insertAdjacentHTML('afterbegin', content)
             if (target) $cru(target).innerHTML = content
-            if (removeClosest) form.closest(removeClosest).remove()
             if (reset) form.reset()
-            if (reloadContainer) {
-                $cruLoadContainer(form)
+            if (reloadContainer) $cruLoadContainer(form)
+            if (removeClosest) {
+                const elToRemove = form.closest(removeClosest)
+                if (elToRemove) elToRemove.remove()
             }
             if (callback) $cruConfig['callbacks'][callback]({status: response.status, data: content}, form)
             $cruLoadEvents()
-            if (redirect) {
-                window.location.href = redirect
-            }
+            if (redirect) window.location.href = redirect
         })
     })
 }
@@ -210,7 +179,8 @@ const $cruCallback = (name, callback) => {
 
 const $cruIsRead = (method) => ['GET', 'HEAD'].includes(method)
 
-const $cruTypeResponse = async (type, response) => 
+const $cruTypeResponse = async (type, response) => {
     type == 'html' ? await response.text():await response.json()
+}
 
 $C()

--- a/src/cru.js
+++ b/src/cru.js
@@ -1,3 +1,4 @@
+
 const $cru = (el) => document.querySelector(el)
 const $crus = (el) => document.querySelectorAll(el)
 
@@ -16,10 +17,21 @@ const $C = (config = false) => {
     $cruLoadEvents()
 }
 
+const $cruLoadElementEvents = () => {
+    $crus('[c-remove]:not(.c-form):not(.loaded)').forEach((el) => {
+        el.classList.add('loaded')
+        el.addEventListener('click', (e) => {
+            const selector = el.getAttribute('c-remove')
+            selector.split(';').forEach(sel => $crus(sel).forEach(e => e.remove()))
+        })
+    })
+}
+
 const $cruLoadEvents = () => {
     $cruLoadRequests()
     $cruLoadFormIntercept()
     $cruLoadAllContainers()
+    $cruLoadElementEvents()
 }
 
 const $cruLoadContainer = async (el) => {
@@ -144,6 +156,7 @@ const $cruLoadFormIntercept = () => {
             const target = form.getAttribute('c-target') || false;
             const reloadContainer = form.getAttribute('c-reload-container') || false;
             const callback = form.getAttribute('c-callback') || false
+            const removeClosest = form.getAttribute('c-remove-closest') || false
             const isRead = $cruIsRead(method)
 
             const data = Object.fromEntries(new FormData(e.target).entries());
@@ -161,6 +174,7 @@ const $cruLoadFormIntercept = () => {
             if (append) $cru(append).insertAdjacentHTML('beforeend', content)
             if (prepend) $cru(prepend).insertAdjacentHTML('afterbegin', content)
             if (target) $cru(target).innerHTML = content
+            if (removeClosest) form.closest(removeClosest).remove()
             if (reset) form.reset()
             if (reloadContainer) {
                 $cruLoadContainer(form)


### PR DESCRIPTION
Adicionação de um novo atributo `c-remove` para remover elementos e melhoria do `c-remove-closest` para formulários.

### Mudanças:

1. **c-remove: Remove seletores especificados**
   
   Novo atributo que permite remover um ou múltiplos elementos, listando os identificadores, separados por espaço.
   
   ```javascript
   const remove = el.getAttribute('c-remove') || false
   if (remove) remove.split(' ').forEach(sel => $crus(sel).forEach(e => e.remove()))
   ```
   
   **Exemplos:**
   - `<button c-remove=".notification">Remove notificação</button>`
   - `<button c-remove="#temp .item">Remove múltiplos</button>` - remove `#temp` E `.item`

2. **c-remove-closest: Agora funciona em formulários (Como o c-remove)**
      
   ```javascript
   const removeClosest = form.getAttribute('c-remove-closest') || false
   if (removeClosest) form.closest(removeClosest).remove()
   ```
   
   **Exemplo:**
   - `<form c-remove-closest="#modal-wrapper">...enviar fecha modal</form>`